### PR TITLE
Change condition to check for empty scores

### DIFF
--- a/binding/python/_eagle.py
+++ b/binding/python/_eagle.py
@@ -640,7 +640,7 @@ class Eagle(object):
                 message_stack=self._get_error_stack(),
             )
 
-        if scores is None:
+        if not scores:
             return None
 
         result = [float(scores[i]) for i in range(len(speaker_profiles))]


### PR DESCRIPTION
The correct way to check for NULL return value
Fixes #160 